### PR TITLE
Add "copy to clipboard" button

### DIFF
--- a/src/components/ErrorToasts.tsx
+++ b/src/components/ErrorToasts.tsx
@@ -25,6 +25,28 @@ export const toastError = (title: JSX.Element, description: JSX.Element) => {
   ));
 };
 
+export const toastSuccess = (title: JSX.Element, description?: JSX.Element) => {
+  toaster.clear();
+  toaster.show((props) => (
+    <Toast
+      class="border rounded-md p-2 text-white bg-green-800 data-[swipe=move]:translate-x-[var(--kb-toast-swipe-move-x)] data-[swipe=cancel]:(translate-x-0 transition-transform duration-200 ease-out) data-[swipe=end]:animate-swipe-out data-[opened]:animate-slide-in data-[closed]:animate-fade-out"
+      toastId={props.toastId}
+    >
+      <div class="flex justify-between">
+        <Toast.Title class="toast__title font-bold">{title}</Toast.Title>
+        <Toast.CloseButton class="toast__close-button">
+          <X />
+        </Toast.CloseButton>
+      </div>
+      {description && (
+        <Toast.Description class="toast__description">
+          {description}
+        </Toast.Description>
+      )}
+    </Toast>
+  ));
+};
+
 export function ErrorToasts() {
   return (
     <Toast.Region>


### PR DESCRIPTION
This PR adds a button under the preview that copies both the PNG and SVG versions of the generated QR code to the clipboard, as an alternative to downloading them. It copies the SVG as plaintext, which is supported in apps like Figma and Affinity, because copying as image/svg+xml doesn't appear to work in Firefox and probably Chrome too. Here's a video of it copying a PNG to Google Slides and an SVG to Figma, after just pressing the button once:

https://github.com/user-attachments/assets/07223e85-2584-4dba-bcbf-2c0dbaa06be3

I think this is valuable because oftentimes I don't need to hold on to a QR code after I've added it to a presentation or used it in a poster, since I can easily recreate it by scanning it and noting down the domain. Copying allows me to iterate faster and download fewer files. Because the current app doesn't allow me to right-click on the preview QR and copy it, this button provides a method to copy the image.

I also made a later change that switches the copy icon to a checkmark when the copy goes through to provide more visual feedback
![zen_eQZPLVKxdC](https://github.com/user-attachments/assets/5570c0b2-3d73-48ce-a003-66afa1cf9faa)
